### PR TITLE
Tweaks to the templates

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -19,7 +19,7 @@ module.exports = {
       env: {
         browser: false
       },
-      files: ['**/*.{cjs,js}'],
+      files: ['**/*.{cjs,js,ts}'],
       parser: '@typescript-eslint/parser',
       parserOptions: {
         ecmaVersion: 'latest',

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,7 +7,7 @@ export default {
   verbose: true,
   resetModules: true,
   clearMocks: true,
-  silent: true,
+  silent: false,
   testMatch: ['**/src/**/*.test.js'],
   reporters: ['default', ['github-actions', { silent: false }], 'summary'],
   collectCoverageFrom: ['src/**/*.js'],

--- a/src/api/example/controllers/example-find-all-controller.js
+++ b/src/api/example/controllers/example-find-all-controller.js
@@ -12,7 +12,7 @@ const exampleFindAllController = {
    * @returns {Promise<*>}
    */
   handler: async (request, h) => {
-    const entities = await findAllExampleData(request.db)
+    const entities = await findAllExampleData(request.db())
 
     return h.response({ message: 'success', entities }).code(200)
   }

--- a/src/api/example/controllers/example-find-one-controller.js
+++ b/src/api/example/controllers/example-find-one-controller.js
@@ -14,7 +14,7 @@ const exampleFindOneController = {
    * @returns {Promise<*>}
    */
   handler: async (request, h) => {
-    const entity = await findExampleData(request.db, request.params.exampleId)
+    const entity = await findExampleData(request.db(), request.params.exampleId)
     if (isNull(entity)) {
       return Boom.boomify(Boom.notFound())
     }

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -9,6 +9,8 @@ import { failAction } from '~/src/helpers/fail-action.js'
 import { secureContext } from '~/src/helpers/secure-context/index.js'
 import { pulse } from '~/src/helpers/pulse.js'
 
+const enablePulse = config.get('enablePulse')
+
 async function createServer() {
   const server = hapi.server({
     port: config.get('port'),
@@ -40,11 +42,19 @@ async function createServer() {
 
   // Hapi Plugins:
   // requestLogger - automatically logs incoming requests
-  // secureContext - loads CA certificates from environment config
   // pulse         - provides shutdown handlers
   // mongoDb       - sets up mongo connection pool and attaches to `server` and `request` objects
+  // secureContext - loads CA certificates from environment config
   // router        - routes used in the app
-  await server.register([requestLogger, secureContext, pulse, mongoDb, router])
+
+  // Add request logger before all other plugins, so we can see errors
+  await server.register(requestLogger)
+
+  if (enablePulse) {
+    await server.register(pulse)
+  }
+
+  await server.register([secureContext, mongoDb, router])
 
   return server
 }

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -97,6 +97,12 @@ const config = convict({
     default: isProduction,
     env: 'ENABLE_SECURE_CONTEXT'
   },
+  enablePulse: {
+    doc: 'Enable Pulse',
+    format: Boolean,
+    default: isProduction,
+    env: 'ENABLE_PULSE'
+  },
   enableMetrics: {
     doc: 'Enable metrics reporting',
     format: Boolean,

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -5,8 +5,9 @@ import { fileURLToPath } from 'node:url'
 const dirname = path.dirname(fileURLToPath(import.meta.url))
 
 const isProduction = process.env.NODE_ENV === 'production'
-const isDev = process.env.NODE_ENV === 'development'
+const isDevelopment = process.env.NODE_ENV === 'development'
 const isTest = process.env.NODE_ENV === 'test'
+
 const config = convict({
   env: {
     doc: 'The application environment.',
@@ -38,7 +39,7 @@ const config = convict({
   isDevelopment: {
     doc: 'If this application running in the development environment',
     format: Boolean,
-    default: isDev
+    default: isDevelopment
   },
   isTest: {
     doc: 'If this application running in the test environment',

--- a/src/helpers/secure-context/secure-context.js
+++ b/src/helpers/secure-context/secure-context.js
@@ -1,16 +1,18 @@
 import tls from 'node:tls'
-import { config } from '~/src/config/index.js'
 
+import { config } from '~/src/config/index.js'
 import { getTrustStoreCerts } from '~/src/helpers/secure-context/get-trust-store-certs.js'
 
+const enableSecureContext = config.get('enableSecureContext')
 /**
+ * Creates a new secure context loaded from Base64 encoded certs
  * @satisfies {ServerRegisterPluginObject<void>}
  */
 const secureContext = {
   plugin: {
     name: 'secure-context',
     register(server) {
-      if (config.get('enableSecureContext')) {
+      if (enableSecureContext) {
         const originalCreateSecureContext = tls.createSecureContext
 
         tls.createSecureContext = function (options = {}) {
@@ -23,18 +25,14 @@ const secureContext = {
           const secureContext = originalCreateSecureContext(options)
 
           trustStoreCerts.forEach((cert) => {
-            // eslint-disable-next-line -- Node.js API not documented
             secureContext.context.addCACert(cert)
           })
 
           return secureContext
         }
-
-        // @ts-expect-error TS2769
-        server.decorate('server', 'secureContext', tls.createSecureContext())
-      } else {
-        server.logger.info('Custom secure context is disabled')
       }
+
+      server.decorate('server', 'getSecureContext', tls.createSecureContext)
     }
   }
 }

--- a/src/helpers/secure-context/secure-context.js
+++ b/src/helpers/secure-context/secure-context.js
@@ -28,6 +28,8 @@ const secureContext = {
             secureContext.context.addCACert(cert)
           })
 
+          server.logger.info('Custom secure context enabled')
+
           return secureContext
         }
       }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,5 @@
     "types": ["jest"]
   },
   "exclude": [".cache", ".public", ".server", "coverage", "node_modules"],
-  "include": ["**/*.cjs", "**/*.js", ".*.cjs", ".*.js"]
+  "include": ["**/*.cjs", "**/*.js", ".*.cjs", ".*.js", "types/**/*.ts"]
 }

--- a/types/cdp-node-backend-template.d.ts
+++ b/types/cdp-node-backend-template.d.ts
@@ -1,0 +1,17 @@
+import { SecureContextOptions, SecureContext } from 'tls'
+import { Db, MongoClient } from 'mongodb'
+import { LockManager } from 'mongo-locks'
+
+declare module '@hapi/hapi' {
+  interface Request {
+    db: () => Db
+    locker: () => LockManager
+  }
+
+  interface Server {
+    db: () => Db
+    locker: () => LockManager
+    mongoClient: () => MongoClient
+    getSecureContext: (options?: SecureContextOptions) => SecureContext
+  }
+}


### PR DESCRIPTION
- Clean up types and remove `@ts` comments
- Wrap pulse in a flag so its only enabled in `production`
- Add custom type declaration so decorators are available on `Server` and `Request`
- Rework decorators so they are all functions
   - Remove `options` that were not being used
   - Update where decorators are used in the app 
- Rework secureContext so the decorator is always available
- Add `isDevelopment` and `isText` consts
- Move `requestLogger` registration to the front
- Turn on logging in tests
