### PR TITLE
Template update proposal config

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,17 @@
+# Local development Environment Variables template
+# To set Environment Variables for your service in CDP environments see https://github.com/DEFRA/cdp-app-config/tree/main/services/cdp-node-backend-template
+# Config documentation can be read on https://github.com/DEFRA/cdp-documentation/blob/main/how-to/config.md
+
+SERVICE_VERSION=
+PORT=
+NODE_ENV=
+LOG_ENABLED=
+LOG_LEVEL=
+LOG_FORMAT=
+LOG_REDACT=
+MONGO_URI=
+MONGO_DATABASE=
+HTTP_PROXY=
+ENABLE_SECURE_CONTEXT=
+ENABLE_METRICS=
+TRACING_HEADER=

--- a/.github/template/template-compose.yml
+++ b/.github/template/template-compose.yml
@@ -24,6 +24,15 @@ services:
       PORT: 8085
       MONGO_URI: "mongodb://mongodb:27017/?tls=true"
       TRUSTSTORE_MONGO: ${MONGODB_TEST_CA_PEM}
+      LOG_ENABLED: true
+      LOG_FORMAT: ecs
+      LOG_LEVEL: info
+      LOG_REDACT: 'req.headers.authorization,req.headers.cookie,res.headers'
+      MONGO_DATABASE: cdp-node-backend-template
+      ENABLE_SECURE_CONTEXT: true
+      ENABLE_METRICS: true
+      TRACING_HEADER: x-cdp-request-id
+      ENVIRONMENT: dev
     healthcheck:
       test: curl http://localhost:8085/health
       start_period: 1s

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ npm-debug.log
 coverage
 .cache
 .eslintcache
+.env
 
 # @shelf/jest-mongodb generated file
 globalConfig.json

--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@ Core delivery platform Node.js Backend Template.
 - [Local development](#local-development)
   - [Setup](#setup)
   - [Development](#development)
+    - [Local Environment Variables](#local-environment-variables)
   - [Testing](#testing)
   - [Production](#production)
+    - [Environment Variables](#environment-variables)
   - [Npm scripts](#npm-scripts)
   - [Update dependencies](#update-dependencies)
   - [Formatting](#formatting)
@@ -58,6 +60,12 @@ To run the application in `development` mode run:
 npm run dev
 ```
 
+#### Local Environment Variables
+
+When developing locally you can provide environment variables via an `.env` file in the root of the repo. Copy the
+[env.template](./.env.template) file and rename it to `.env`. Your teammates will have a copy with the values you
+need. They can securely share this with you.
+
 ### Testing
 
 To test the application run:
@@ -73,6 +81,10 @@ To mimic the application running in `production` mode locally run:
 ```bash
 npm start
 ```
+
+#### Environment Variables
+
+To set Environment Variables for your service in the CDP environments see https://github.com/DEFRA/cdp-app-config
 
 ### Npm scripts
 

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "postversion": "git add package.json package-lock.json && git commit -m $npm_package_version",
     "test": "node --no-experimental-require-module ./node_modules/jest/bin/jest.js --coverage --verbose --runInBand",
     "test:watch": "node --no-experimental-require-module ./node_modules/jest/bin/jest.js --watch",
-    "server:watch": "nodemon --inspect=0.0.0.0 --ext js,json --legacy-watch ./src",
-    "server:debug": "nodemon --inspect-brk=0.0.0.0 --ext js,json --legacy-watch ./src",
+    "server:watch": "nodemon --inspect=0.0.0.0 --ext js,json --env-file=.env --legacy-watch ./src",
+    "server:debug": "nodemon --inspect-brk=0.0.0.0 --ext js,json --env-file=.env --legacy-watch ./src",
     "start": "NODE_ENV=production node --use-strict .",
     "setup:husky": "node -e \"try { (await import('husky')).default() } catch (e) { if (e.code !== 'ERR_MODULE_NOT_FOUND') throw e }\" --input-type module"
   },

--- a/src/config.js
+++ b/src/config.js
@@ -6,9 +6,6 @@ import { convictValidateMongoUri } from './common/helpers/convict/validate-mongo
 convict.addFormat(convictValidateMongoUri)
 convict.addFormats(convictFormatWithValidator)
 
-const isProduction = process.env.NODE_ENV === 'production'
-const isTest = process.env.NODE_ENV === 'test'
-
 const config = convict({
   serviceVersion: {
     doc: 'The service version, this variable is injected into your docker container in CDP environments',
@@ -53,7 +50,7 @@ const config = convict({
     isEnabled: {
       doc: 'Is logging enabled',
       format: Boolean,
-      default: !isTest,
+      default: true,
       env: 'LOG_ENABLED'
     },
     level: {
@@ -65,15 +62,18 @@ const config = convict({
     format: {
       doc: 'Format to output logs in',
       format: ['ecs', 'pino-pretty'],
-      default: isProduction ? 'ecs' : 'pino-pretty',
+      default: 'pino-pretty',
       env: 'LOG_FORMAT'
     },
     redact: {
       doc: 'Log paths to redact',
       format: Array,
-      default: isProduction
-        ? ['req.headers.authorization', 'req.headers.cookie', 'res.headers']
-        : ['req', 'res', 'responseTime']
+      default: [
+        'req.headers.authorization',
+        'req.headers.cookie',
+        'res.headers'
+      ],
+      env: 'LOG_REDACT'
     }
   },
   mongo: {
@@ -100,13 +100,13 @@ const config = convict({
   isSecureContextEnabled: {
     doc: 'Enable Secure Context',
     format: Boolean,
-    default: isProduction,
+    default: false,
     env: 'ENABLE_SECURE_CONTEXT'
   },
   isMetricsEnabled: {
     doc: 'Enable metrics reporting',
     format: Boolean,
-    default: isProduction,
+    default: false,
     env: 'ENABLE_METRICS'
   },
   tracing: {


### PR DESCRIPTION
# Local separation of config values and schema

## Issue
Currently we have a mix of schema and values, some defaults in our `config.js` file. Rather than setting all defaults in `cdp-app-config` we are relying, for some config, on the defaults set in an applications config. This isn't ideal.

This problem has been solved in CDP environments with a mix of the use of Secrets via the Portal Frontend and Environment variables via https://github.com/DEFRA/cdp-app-config. Locally it needs a little bit of work.

## Proposal
Proposal for separating out config values for development from the config schema. So its easier to see things in config and easy to set environment variables on a local development service and easy not to commit values in the `config.js` file.

> [!IMPORTANT]
> The below items need completing before this can be merged
- [ ] Discuss with platform team
- [ ] Add defaults to `cdp-app-config` environments rather than programatically deciding them in config in apps

## Of Note
- I have stuck with `convictjs` for the moment. Swapping out to `Joi` could be part of this or another body of work?
- Remove `test`, `development` and `production` `NODE_ENV` work in config. We would like not to encourage the use of `NODE_ENV` in apps see - https://nodejs.org/en/learn/getting-started/nodejs-the-difference-between-development-and-production