### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ npm-debug.log
 coverage
 .cache
 .eslintcache
+.env


### PR DESCRIPTION
Dear @DEFRA/cdp-platform, for security I think it would be beneficial to add `.env` to the `.gitignore` file.  Most projects will add their own `.env` file and it's very easy to commit this as you expect this to be ignored by default. 